### PR TITLE
Add exception handling for Alert Rules in Annotations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,11 +7,6 @@ services:
     ports:
       - 3000:3000/tcp
     environment:
-      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
-      - GF_AUTH_ANONYMOUS_ENABLED=true
-      - GF_AUTH_BASIC_ENABLED=false
-      - GF_UNIFIED_ALERTING_ENABLED=true
-      - GF_ENABLE_GZIP=true
       - GF_DEFAULT_APP_MODE=development
       - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/etc/grafana/provisioning/dashboards/panels.json
     volumes:

--- a/package.json
+++ b/package.json
@@ -31,5 +31,5 @@
     "upgrade": "yarn upgrade --latest",
     "watch": "grafana-toolkit plugin:dev --watch"
   },
-  "version": "1.2.0"
+  "version": "1.3.0"
 }

--- a/src/api/annotations.ts
+++ b/src/api/annotations.ts
@@ -194,7 +194,7 @@ export const getAnnotationsFrame = async (
    * Alert Rules
    */
   const alertRules: { [id: number]: AlertRule } = {};
-  const rules = await getAlertRules(api);
+  const rules = await getAlertRules(api).catch(() => []);
   rules.forEach((rule) => (alertRules[rule.id] = rule));
 
   /**


### PR DESCRIPTION
Resolves #38.

Alert Rules Provisioning endpoint was introduced in 9.4.0 and requires Admin permissions.